### PR TITLE
Changes repo.spring.io to https in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <repositories>
         <repository>
             <id>spring-milestones</id>
-            <url>http://repo.spring.io/libs-milestone/</url>
+            <url>https://repo.spring.io/libs-milestone/</url>
         </repository>
         <repository>
             <id>mvnrepository</id>


### PR DESCRIPTION
This fixes:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:34 min
[INFO] Finished at: 2020-05-06T09:56:30+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project codeontology: Could not resolve dependencies for project org.codeontology:codeontology:jar:1.0-SNAPSHOT: Failed to collect dependencies at fr.inria.gforge.spoon:spoon-core:jar:5.1.0 -> org.eclipse.jdt:org.eclipse.jdt.core:jar:3.12.0.v20150913-1717: Failed to read artifact descriptor for org.eclipse.jdt:org.eclipse.jdt.core:jar:3.12.0.v20150913-1717: Could not transfer artifact org.eclipse.jdt:org.eclipse.jdt.core:pom:3.12.0.v20150913-1717 from/to spring-milestones (http://repo.spring.io/libs-milestone/): Access denied to: http://repo.spring.io/libs-milestone/org/eclipse/jdt/org.eclipse.jdt.core/3.12.0.v20150913-1717/org.eclipse.jdt.core-3.12.0.v20150913-1717.pom -> [Help 1]
```
When trying to resolve http://repo.spring.io/ in a web browser today I get:

    HTTP is not supported. Please use HTTPS